### PR TITLE
Switch to bsdtar to avoid clash with overlay fs driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,9 +76,11 @@ RUN apk add --no-cache \
   libstdc++ \
   openssl \
   subversion \
-  tar \
+  libarchive-tools \
   && mkdir -p /var/run/mesos \
-  && rm -v /usr/bin/docker-* /usr/bin/dockerd 
+  && rm -v /usr/bin/docker-* /usr/bin/dockerd \
+  && cp $(which tar) $(which tar)~ \
+  && ln -sf $(which bsdtar) $(which tar)
 
 # Mesos Default Options
 ENV \ 


### PR DESCRIPTION
I encountered this issue when trying to launch a container using the Universal containerizer.

```
W0207 23:57:47.124251    17 http.cpp:2381] Failed to launch nested container 20161492-09ff-4673-b780-d337b1000f7a.daae741b-e65d-4153-aa3b-c74107d687b1: Collect failed: Subprocess 'tar, tar, -x, -f, /tmp/mesos/store/docker/staging/HePnhL/sha256:4fb8f15b6159b3caa7892aa866d95724c06a19fa357efdbccfaff5c2e95e7c6f, -C, /tmp/mesos/store/docker/staging/HePnhL/6c70ab934f925ea8ab332d48815d9b27d056b62ba84a8035505cfb94f71892fe/rootfs' failed: tar: usr/bin: Directory renamed before its status could be extracted
tar: sbin: Directory renamed before its status could be extracted
tar: lib/systemd/system/sockets.target.wants: Directory renamed before its status could be extracted
tar: lib/systemd/system/multi-user.target.wants: Directory renamed before its status could be extracted
tar: lib/systemd/system: Directory renamed before its status could be extracted
tar: lib/systemd: Directory renamed before its status could be extracted
tar: lib: Directory renamed before its status could be extracted
tar: etc/systemd/system/network-online.target.wants: Directory renamed before its status could be extracted
tar: etc/systemd/system/multi-user.target.wants: Directory renamed before its status could be extracted
tar: etc/systemd/system: Directory renamed before its status could be extracted
tar: etc/systemd: Directory renamed before its status could be extracted
tar: etc/ssl/certs: Directory renamed before its status could be extracted
tar: etc/ssl: Directory renamed before its status could be extracted
tar: etc/sgml: Directory renamed before its status could be extracted
tar: etc/rcS.d: Directory renamed before its status could be extracted
tar: etc/rc6.d: Directory renamed before its status could be extracted
tar: etc/rc5.d: Directory renamed before its status could be extracted
tar: etc/rc4.d: Directory renamed before its status could be extracted
tar: etc/rc3.d: Directory renamed before its status could be extracted
tar: etc/rc2.d: Directory renamed before its status could be extracted
tar: etc/rc0.d: Directory renamed before its status could be extracted
tar: etc/ld.so.conf.d: Directory renamed before its status could be extracted
tar: etc/fonts/conf.d: Directory renamed before its status could be extracted
tar: etc/fonts: Directory renamed before its status could be extracted
tar: etc/dhcp/dhclient-exit-hooks.d: Directory renamed before its status could be extracted
tar: etc/dhcp/dhclient-enter-hooks.d: Directory renamed before its status could be extracted
tar: etc/dhcp: Directory renamed before its status could be extracted
tar: etc/apparmor/init/network-interface-security: Directory renamed before its status could be extracted
tar: etc/apparmor/init: Directory renamed before its status could be extracted
tar: etc/apparmor: Directory renamed before its status could be extracted
tar: etc/alternatives: Directory renamed before its status could be extracted
tar: etc: Directory renamed before its status could be extracted
tar: Exiting with failure status due to previous errors
```

Whenever docker is running with the overlay filesystem driver, then some black magic happens under the hood which triggers this error inside of the tar executable: https://github.com/coreos/bugs/issues/1095#issuecomment-233793361

This issue can be circumvented by using bsdtar (included in libarchive-tools): https://github.com/coreos/bugs/issues/1095#issuecomment-336872867
